### PR TITLE
Consume Leaderboard API

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -60,8 +60,11 @@ li {
   margin-top: 10px;
 }
 
-.recent-scores-container li {
-  margin: 5px 0;
+.score {
+  display: flex;
+  justify-content: space-between;
+  padding: 5px 10px;
+  font-weight: 500;
 }
 
 .score:nth-child(even) {

--- a/src/modules/AddScoreUI.js
+++ b/src/modules/AddScoreUI.js
@@ -10,6 +10,8 @@ const onFormSubmit = () => {
     const { name, score } = addScoreForm.elements;
 
     await Scores.addScore({ user: name.value, score: Number(score.value, 10) });
+    event.target.reset();
+    name.focus();
 
     renderScore();
   });

--- a/src/modules/AddScoreUI.js
+++ b/src/modules/AddScoreUI.js
@@ -1,6 +1,20 @@
 import renderScore from "./ScoreUI.js";
 import Scores from "./Scores.js";
 
+const onFormSubmit = () => {
+  const addScoreForm = document.querySelector('#form-add-score');
+
+  addScoreForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+
+    const { name, score } = addScoreForm.elements;
+
+    await Scores.addScore({ user: name.value, score: Number(score.value, 10) });
+
+    renderScore();
+  })
+}
+
 const renderFormAddScore = () => {
   const mainSection = document.getElementById('main');
   const addScoreSection = document.createElement('section');

--- a/src/modules/AddScoreUI.js
+++ b/src/modules/AddScoreUI.js
@@ -1,5 +1,5 @@
-import renderScore from "./ScoreUI.js";
-import Scores from "./Scores.js";
+import renderScore from './ScoreUI.js';
+import Scores from './Scores.js';
 
 const onFormSubmit = () => {
   const addScoreForm = document.querySelector('#form-add-score');
@@ -12,8 +12,8 @@ const onFormSubmit = () => {
     await Scores.addScore({ user: name.value, score: Number(score.value, 10) });
 
     renderScore();
-  })
-}
+  });
+};
 
 const renderFormAddScore = () => {
   const mainSection = document.getElementById('main');

--- a/src/modules/AddScoreUI.js
+++ b/src/modules/AddScoreUI.js
@@ -1,3 +1,6 @@
+import renderScore from "./ScoreUI.js";
+import Scores from "./Scores.js";
+
 const renderFormAddScore = () => {
   const mainSection = document.getElementById('main');
   const addScoreSection = document.createElement('section');
@@ -10,6 +13,8 @@ const renderFormAddScore = () => {
           <input type="submit" value="Submit" class="btn btn-submit">
         </form>`;
   mainSection.appendChild(addScoreSection);
+
+  onFormSubmit();
 };
 
 export default renderFormAddScore;

--- a/src/modules/ScoreUI.js
+++ b/src/modules/ScoreUI.js
@@ -1,25 +1,24 @@
-import Scores from "./Scores";
+import Scores from './Scores.js';
 
 const recentScoresContainer = document.querySelector('.recent-scores-container');
 const btnRefresh = document.querySelector('.btn-refresh');
 
-btnRefresh.addEventListener('click', () => {
-  console.log("refresh clicked")
-  Scores.getScores();
-  renderScore();
-});
-
 const renderScore = async () => {
-  const recentScores = await Scores.getScores()
+  const recentScores = await Scores.getScores();
 
-  recentScoresContainer.innerHTML = "";
+  recentScoresContainer.innerHTML = '';
 
   recentScores.forEach(({ user, score }) => {
     const scoreItem = document.createElement('li');
     scoreItem.classList.add('score');
-    scoreItem.innerHTML = `<span>${user}</span><span>${score}</span>`
+    scoreItem.innerHTML = `<span>${user}</span><span>${score}</span>`;
     recentScoresContainer.appendChild(scoreItem);
   });
 };
+
+btnRefresh.addEventListener('click', () => {
+  Scores.getScores();
+  renderScore();
+});
 
 export default renderScore;

--- a/src/modules/ScoreUI.js
+++ b/src/modules/ScoreUI.js
@@ -1,20 +1,16 @@
-const scores = [
-  { name: 'Name', score: 100 },
-  { name: 'Name', score: 20 },
-  { name: 'Name', score: 50 },
-  { name: 'Name', score: 78 },
-  { name: 'Name', score: 125 },
-  { name: 'Name', score: 77 },
-  { name: 'Name', score: 42 },
-];
+import Scores from "./Scores";
 
 const recentScoresContainer = document.querySelector('.recent-scores-container');
 
-const renderScore = () => {
-  scores.forEach((score) => {
+const renderScore = async () => {
+  const recentScores = await Scores.getScores()
+
+  recentScoresContainer.innerHTML = "";
+
+  recentScores.forEach(({ user, score }) => {
     const scoreItem = document.createElement('li');
     scoreItem.classList.add('score');
-    scoreItem.textContent = `${score.name} ${score.score}`;
+    scoreItem.textContent = `${user} ${score}`;
     recentScoresContainer.appendChild(scoreItem);
   });
 };

--- a/src/modules/ScoreUI.js
+++ b/src/modules/ScoreUI.js
@@ -1,6 +1,13 @@
 import Scores from "./Scores";
 
 const recentScoresContainer = document.querySelector('.recent-scores-container');
+const btnRefresh = document.querySelector('.btn-refresh');
+
+btnRefresh.addEventListener('click', () => {
+  console.log("refresh clicked")
+  Scores.getScores();
+  renderScore();
+});
 
 const renderScore = async () => {
   const recentScores = await Scores.getScores()
@@ -10,7 +17,7 @@ const renderScore = async () => {
   recentScores.forEach(({ user, score }) => {
     const scoreItem = document.createElement('li');
     scoreItem.classList.add('score');
-    scoreItem.textContent = `${user} ${score}`;
+    scoreItem.innerHTML = `<span>${user}</span><span>${score}</span>`
     recentScoresContainer.appendChild(scoreItem);
   });
 };

--- a/src/modules/Scores.js
+++ b/src/modules/Scores.js
@@ -2,13 +2,11 @@ const gameId = 'OYxzLGROB4qVtRjyvig5';
 const BASE_URL = 'https://us-central1-js-capstone-backend.cloudfunctions.net/api/games';
 
 class Scores {
-  static getScores() {
-    return this.recentScores = fetch(`${BASE_URL}/${gameId}/scores/`)
-      .then(response => response.json())
-      .then(data => data.result)
-      .catch((error) => {
-        console.error('Error:', error);
-      });
+  static async getScores() {
+    return fetch(`${BASE_URL}/${gameId}/scores/`)
+      .then((response) => response.json())
+      .then((data) => data.result)
+      .catch((error) => error);
   }
 
   static async addScore({ user, score }) {
@@ -24,9 +22,7 @@ class Scores {
       })
       .then((response) => response.json())
       .then((data) => data)
-      .catch((error) => {
-        console.error('Error:', error);
-      });
+      .catch((error) => error);
   }
 }
 

--- a/src/modules/Scores.js
+++ b/src/modules/Scores.js
@@ -10,6 +10,24 @@ class Scores {
         console.error('Error:', error);
       });
   }
+
+  static async addScore({ user, score }) {
+    const newScore = { user, score };
+
+    await fetch(`${BASE_URL}/${gameId}/scores/`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-type': 'application/json; charset=UTF-8',
+        },
+        body: JSON.stringify(newScore),
+      })
+      .then((response) => response.json())
+      .then((data) => data)
+      .catch((error) => {
+        console.error('Error:', error);
+      });
+  }
 }
 
 export default Scores;

--- a/src/modules/Scores.js
+++ b/src/modules/Scores.js
@@ -1,0 +1,15 @@
+const gameId = 'OYxzLGROB4qVtRjyvig5';
+const BASE_URL = 'https://us-central1-js-capstone-backend.cloudfunctions.net/api/games';
+
+class Scores {
+  static getScores() {
+    return this.recentScores = fetch(`${BASE_URL}/${gameId}/scores/`)
+      .then(response => response.json())
+      .then(data => data.result)
+      .catch((error) => {
+        console.error('Error:', error);
+      });
+  }
+}
+
+export default Scores;


### PR DESCRIPTION
## What this PR does
 - Created new game with ID `OYxzLGROB4qVtRjyvig5`.
 - Fetch (GET) scores on window load event.
 - Fetch (GET) scores on "Refresh" button click and render them.
 - POST new score on form "Submit" event to the `Leaderboard API`.

## How to test it
  -  clone the repository by running\
    `git clone https://github.com/gtekle/leaderboard.git`
  - navigate to the folder\
    `cd leaderboard`
  - Install packages\
    `npm install`
  - To run application using webpack-dev-server\
    `npm start`

## Details

- Fetch scores from `Leaderboard API` and render
- Add new score to `Leaderboard API` on form submit.
- Fetch score from `Leaderboard API` on refresh button click and render
- Fix linter errors